### PR TITLE
Update readme with more specific instructions on running unit and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ own unit tests.
 
 Prior to using the generated `zkey` files for corresponding circuits, it is now required to compile `circom` locally. To get started the follow the instructions [here](https://docs.circom.io/getting-started/installation/)
 and be sure that the installation directory matches the value in the `circom` field inside `circuits/circomHelperConfig.json`.
+Move from $HOME/.cargo/bin to <maci root>/.local/bin/circom
 
 For example:
 ```json
 {
-    "circom": "../$RELATIVE_PATH_TO_CIRCOM"
+    "circom": "../.local/bin/circom"
 }
 ```
 
@@ -126,7 +127,7 @@ For example:
 The following submodules contain unit tests: `core`, `crypto`, `circuits`,
 `contracts`, and `domainobjs`.
 
-Except for the `contracts` submodule, run unit tests as such (the following
+Except for the `contracts` and `circuits` submodule, run unit tests as such (the following
 example is for `crypto`):
 
 ```bash
@@ -134,10 +135,28 @@ cd crypto
 npm run test
 ```
 
-For `contracts` and `integrationTests`, run the tests one by one. This prevents
-incorrect nonce errors.
+For `circuits`, first build the zk-SNARKs as explained above and then run in one terminal:
 
-First, start a Hardhat instance in a separate terminal:
+```bash
+cd circuits
+npm run circom-helper
+```
+wait for *Launched JSON-RPC server at port 9001* message and then run in another terminal:
+
+```bash
+cd circuits
+npm run test
+```
+
+Note that some tests might fail due to jest timeout. You can fix this by adjusting the timeout period defined at the top of the test file.
+
+For example, in the file *MessageToCommand.test.ts*, increase timeout_in_ms on this line: ```jest.setTimeout(<timeout_in_ms>)```.
+
+For `contracts` and `integrationTests`, run the tests one by one. This prevents incorrect nonce errors.
+
+For `contracts`, first, compile the contracts as explained above.
+
+Then, start a Hardhat instance in a separate terminal:
 
 ```bash
 cd contracts
@@ -170,16 +189,15 @@ cd contracts
 ./scripts/runTestsInCi.sh
 ```
 
-Or run all integration tests (this also starts its own Hardhat instance):
+
+For `integrationTests`, first make sure to install necessary tooling for rapidsnark as explained above, build the zk-SNARKs and generate their proving and verifying keys.
+
+Run all integration tests (this also starts its own Hardhat instance so make sure to any running hardhat instance):
 
 ```bash
 cd integrationTests
 ./scripts/runTestsInCi.sh
 ```
-
-You can ignore the Hardhat errors which this script emits as you should already
-have Hardhat running in a separate terminal. Otherwise, you will have to exit
-Ganache using the `kill` command.
 
 
 ### Docker

--- a/circuits/circomHelperConfig.json
+++ b/circuits/circomHelperConfig.json
@@ -1,5 +1,5 @@
 {
-    "circom": "../../.local/bin/circom",
+    "circom": "../.local/bin/circom",
     "snarkjs": "./node_modules/snarkjs/build/cli.cjs",
     "circuitDirs": [
         "./circom/prod/",


### PR DESCRIPTION
This PR adds more detailed instructions on running both unit and integration tests to the readme.md. It also introduces a hardcoded relative path for circom binary for easier setup.

All tests have been executed by following the updated instruction set.