### PR TITLE
Feat/new key message command circuit tests

### DIFF
--- a/circuits/ts/__tests__/GenerateKeyFromDeactivated.test.ts
+++ b/circuits/ts/__tests__/GenerateKeyFromDeactivated.test.ts
@@ -87,11 +87,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
         it('should accept proof based on deactivation messages', async () => {
             const salt = (new Keypair()).privKey.rawPrivKey
 
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
-
             const DEACT_TREE_ARITY = 5;
 
             const deactivatedKeys = new IncrementalQuinTree(
@@ -155,11 +150,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
             
             const salt = (new Keypair()).privKey.rawPrivKey
 
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
-
             const DEACT_TREE_ARITY = 5;
 
             const deactivatedKeys = new IncrementalQuinTree(
@@ -222,11 +212,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
             
             const salt = (new Keypair()).privKey.rawPrivKey
 
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
-
             const DEACT_TREE_ARITY = 5;
 
             const deactivatedKeys = new IncrementalQuinTree(
@@ -288,11 +273,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
             const keyPairNotInStateTree = new Keypair(new PrivKey(BigInt(999)));
             
             const salt = (new Keypair()).privKey.rawPrivKey
-
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
 
             const DEACT_TREE_ARITY = 5;
 
@@ -363,11 +343,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
 
             const salt = (new Keypair()).privKey.rawPrivKey
 
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
-
             const DEACT_TREE_ARITY = 5;
 
             const deactivatedKeys = new IncrementalQuinTree(
@@ -427,11 +402,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
         it('should throw because elgamalRerandomize output c1r, c2r passed to circuit is invalid', async () => {
             
             const salt = (new Keypair()).privKey.rawPrivKey
-
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
 
             const DEACT_TREE_ARITY = 5;
 
@@ -495,11 +465,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
         it('should throw because nulifier hash passed to circuit as part of input hash is invalid', async () => {
             
             const salt = (new Keypair()).privKey.rawPrivKey
-
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
 
             const DEACT_TREE_ARITY = 5;
 
@@ -611,11 +576,6 @@ describe('GenerateKeyFromDeactivated circuit', () => {
 
         it('should accept proof based on deactivation messages', async () => {
             const salt = (new Keypair()).privKey.rawPrivKey
-
-            const messageArr = [];
-            for (let i = 0; i < maxValues.maxMessages; i += 1) {
-                messageArr.push(new Message(BigInt(0), Array(10).fill(BigInt(0))))
-            }
 
             const DEACT_TREE_ARITY = 5;
 

--- a/circuits/ts/__tests__/NewKeyMessageToCommand.test.ts
+++ b/circuits/ts/__tests__/NewKeyMessageToCommand.test.ts
@@ -164,11 +164,27 @@ describe('NewKeyMessageToCommand circuit', () => {
 
             const witness = await genWitness(circuit, inputs);
             expect(witness.length > 0).toBeTruthy();
-            
+
+            const decodednewPubKey0 = await getSignalByName(circuit, witness, 'main.newPubKey[0]');
+            const decodednewPubKey1 = await getSignalByName(circuit, witness, 'main.newPubKey[1]');            
             const decodedNewCreditBalance = await getSignalByName(circuit, witness, 'main.newCreditBalance');
+            const decodedNulifier = await getSignalByName(circuit, witness, 'main.nullifier');
+            const decodedPollId = await getSignalByName(circuit, witness, 'main.pollId');
+            const decodedC1r0 = await getSignalByName(circuit, witness, 'main.c1r[0]');
+            const decodedC1r1 = await getSignalByName(circuit, witness, 'main.c1r[1]');
+            const decodedC2r0 = await getSignalByName(circuit, witness, 'main.c2r[0]');
+            const decodedC2r1 = await getSignalByName(circuit, witness, 'main.c2r[1]');
             const decodedStatus = await getSignalByName(circuit, witness, 'main.isValidStatus');
-            
+
+            expect(newUserKeypair.pubKey.rawPubKey[0]).toEqual(BigInt(decodednewPubKey0));
+            expect(newUserKeypair.pubKey.rawPubKey[1]).toEqual(BigInt(decodednewPubKey1));
             expect(BigInt(voiceCreditBalance)).toEqual(BigInt(decodedNewCreditBalance));
+            expect(nullifier).toEqual(BigInt(decodedNulifier));
+            expect(BigInt(pollId)).toEqual(BigInt(decodedPollId));
+            expect(c1r[0]).toEqual(BigInt(decodedC1r0));
+            expect(c1r[1]).toEqual(BigInt(decodedC1r1));
+            expect(c2r[0]).toEqual(BigInt(decodedC2r0));
+            expect(c2r[1]).toEqual(BigInt(decodedC2r1));
             expect(BigInt(decodedStatus)).toEqual(BigInt(1));
         })
     })

--- a/circuits/ts/__tests__/NewKeyMessageToCommand.test.ts
+++ b/circuits/ts/__tests__/NewKeyMessageToCommand.test.ts
@@ -88,7 +88,7 @@ describe('NewKeyMessageToCommand circuit', () => {
             poll = maciState.polls[pollId]
         })
 
-        it('should decrypt new key messages', async () => {
+        it('should decrypt new key messages if all input params are correct', async () => {
             const salt = (new Keypair()).privKey.rawPrivKey
 
             const DEACT_TREE_ARITY = 5;
@@ -175,7 +175,7 @@ describe('NewKeyMessageToCommand circuit', () => {
             expect(BigInt(decodedStatus)).toEqual(BigInt(1));
         })
 
-        it('should throw because random private key passed to circuit instead of coordinators', async () => {
+        it('should return isValidStatus != 1 because random private key passed to circuit instead of coordinators', async () => {
             const randomKeypair = new Keypair(new PrivKey(BigInt(999)));
 
             const salt = (new Keypair()).privKey.rawPrivKey
@@ -246,7 +246,7 @@ describe('NewKeyMessageToCommand circuit', () => {
             expect(BigInt(decodedStatus)).not.toEqual(BigInt(1));
         })
 
-        it('should throw because random public key passed to circuit instead of shared one', async () => {
+        it('should return isValidStatus != 1 because random public key passed to circuit instead of shared one', async () => {
             const randomKeypair = new Keypair(new PrivKey(BigInt(999)));
             const salt = (new Keypair()).privKey.rawPrivKey
 
@@ -316,7 +316,7 @@ describe('NewKeyMessageToCommand circuit', () => {
             expect(BigInt(decodedStatus)).not.toEqual(BigInt(1));
         })
 
-        it('should throw because malformed message passed to circuit', async () => {
+        it('should return isValidStatus != 1 because malformed message passed to circuit', async () => {
             const salt = (new Keypair()).privKey.rawPrivKey
 
             const DEACT_TREE_ARITY = 5;
@@ -371,20 +371,22 @@ describe('NewKeyMessageToCommand circuit', () => {
                 c2,
             )
 
+            const malformedMessageAsCircuitInputs = [
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0),
+                BigInt(0)
+            ]
+
             const inputs = stringifyBigInts({
-                message: [
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0),
-                    BigInt(0)
-                ],
+                message: malformedMessageAsCircuitInputs,
                 encPrivKey: coordinatorKeypair.privKey.asCircuitInputs(),
                 encPubKey: encPubKey.asCircuitInputs(),
             });

--- a/circuits/ts/__tests__/NewKeyMessageToCommand.test.ts
+++ b/circuits/ts/__tests__/NewKeyMessageToCommand.test.ts
@@ -1,5 +1,4 @@
 jest.setTimeout(1200000)
-import * as fs from 'fs'
 import { 
     genWitness,
     getSignalByName,
@@ -12,7 +11,6 @@ import {
 
 import {
     PrivKey,
-    PubKey,
     Keypair,
     PCommand,
     KCommand,
@@ -22,8 +20,6 @@ import {
 
 import {
     hash2,
-    encrypt,
-    sha256Hash,
     hash5,
     IncrementalQuinTree,
     elGamalRerandomize,
@@ -53,15 +49,12 @@ const coordinatorKeypair = new Keypair()
 const circuit = 'newKeyMessageToCommand_test'
 
 describe('NewKeyMessageToCommand circuit', () => {
-    describe('1 user, 1 deactivation messages', () => {
+    describe('1 signup, 1 deactivation messages', () => {
         const maciState = new MaciState()
-        const voteWeight = BigInt(0)
-        const voteOptionIndex = BigInt(0)
         let stateIndex
         let pollId
         let poll
-        const messages: Message[] = []
-        const commands: PCommand[] = []
+        let numOfSignups = 0;
         const H0 = BigInt('8370432830353022751713833565135785980866757267633941821328460903436894336785');
         const userKeypair = new Keypair(new PrivKey(BigInt(1)));
         const newUserKeypair = new Keypair(new PrivKey(BigInt(999)));
@@ -74,6 +67,8 @@ describe('NewKeyMessageToCommand circuit', () => {
                 // BigInt(1), 
                 BigInt(Math.floor(Date.now() / 1000)),
             )
+
+            numOfSignups++;
 
             // Merge state tree
             maciState.stateAq.mergeSubRoots(0)
@@ -133,7 +128,6 @@ describe('NewKeyMessageToCommand circuit', () => {
                 c1,
                 c2,
             );
-            const numSignUps = BigInt(1);
 
             const nullifier = hash2([BigInt(userKeypair.privKey.asCircuitInputs()), salt]);
 
@@ -151,7 +145,7 @@ describe('NewKeyMessageToCommand circuit', () => {
                 userKeypair.privKey,
                 maciState.stateLeaves,
                 maciState.stateTree,
-                BigInt(1),
+                BigInt(numOfSignups),
                 stateIndex,
                 salt,
                 coordinatorKeypair.pubKey,
@@ -161,9 +155,6 @@ describe('NewKeyMessageToCommand circuit', () => {
                 c1,
                 c2,
             )
-
-            // const encMessage = kCommand.encrypt(sharedKey);
-            // console.log(kCommand);
 
             const inputs = stringifyBigInts({
                 message: message.asCircuitInputs(),


### PR DESCRIPTION
  NewKeyMessageToCommand circuit
    1 signup, 1 deactivation messages
      ✓ should decrypt new key messages (2428 ms)
      ✓ should return isValidStatus != 1 because random private key passed to circuit instead of coordinators (1418 ms)
      ✓ should return isValidStatus != 1 because random public key passed to circuit instead of shared one (1232 ms)
      ✓ should return isValidStatus != 1 because malformed message passed to circuit (1260 ms)