### PR TITLE
Feature/generate new key smart contract method

### DIFF
--- a/cli/tests/prepare_test.sh
+++ b/cli/tests/prepare_test.sh
@@ -29,8 +29,9 @@ init_maci() {
         --tally-votes-zkey "$ZKEYS_DIR"/TallyVotes_"$TALLY_VOTES_PARAMS".0.zkey \
         $SET_VERIFYING_KEYS_FLAG_SUBSIDY
 
+    # TODO: Make signup-deadline dynamic now + 30 days for example
     $MACI_CLI create \
-        --signup-deadline 1689834390 \
+        --signup-deadline 1692424915 \
         --deactivation-period 86400
 }
 

--- a/cli/ts/completeDeactivation.ts
+++ b/cli/ts/completeDeactivation.ts
@@ -143,7 +143,6 @@ const completeDeactivation = async (args: any) => {
 	const [maciContractAbi] = parseArtifact('MACI');
 	const [mpContractAbi] = parseArtifact('MessageProcessor');
 	const [pollContractAbi] = parseArtifact('Poll');
-	const [accQueueContractAbi] = parseArtifact('AccQueue');
 
 	// Verify that MACI contract address is deployed at the given address
 	const signer = await getDefaultSigner();

--- a/contracts/contracts/DomainObjs.sol
+++ b/contracts/contracts/DomainObjs.sol
@@ -14,7 +14,7 @@ contract IMessage {
     uint8 constant MESSAGE_DATA_LENGTH = 10;
 
     struct Message {
-        uint256 msgType; // 1: vote message (size 10), 2: topup message (size 2), 3: deactivate key, 4: generate new key
+        uint256 msgType; // 1: vote message (size 10), deactivate key (size 10); 2: topup message (size 2); 3: generate new key (size 10);
         uint256[MESSAGE_DATA_LENGTH] data; // data length is padded to size 10
     }
 }

--- a/contracts/contracts/MessageProcessor.sol
+++ b/contracts/contracts/MessageProcessor.sol
@@ -141,6 +141,7 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
      * @param _batchLeaves Deactivated keys leaves
      * @param _batchSize The capacity of the subroot of the deactivated keys tree
      */
+     // TODO: reschuffle - Register DeactivateKey event and make sure all listeners switched 
     function confirmDeactivation(
         uint256[][] memory _batchLeaves,
         uint256 _batchSize,
@@ -200,13 +201,9 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
 
         ) = poll.extContracts();
 
-        (, uint8 messageTreeSubDepth, uint8 messageTreeDepth, ) = poll
-            .treeDepths();
-
         {
             (uint256 deployTime, ) = poll.getDeployTimeAndDuration();
 
-            uint256 secondsPassed = block.timestamp - deployTime;
             require(
                 block.timestamp - deployTime > maci.deactivationPeriod(),
                 "Deactivation period has not passed"
@@ -237,13 +234,12 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
 
         ) = poll.extContracts();
 
-        (, uint8 messageTreeSubDepth, uint8 messageTreeDepth, ) = poll
+        (, , uint8 messageTreeDepth, ) = poll
             .treeDepths();
 
         {
             (uint256 deployTime, ) = poll.getDeployTimeAndDuration();
 
-            uint256 secondsPassed = block.timestamp - deployTime;
             require(
                 block.timestamp - deployTime > maci.deactivationPeriod(),
                 "Deactivation period has not passed"
@@ -269,6 +265,7 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
         require(verifier.verify(_proof, vk, input), "Verification failed");
     }
 
+    // TODO: Perform all the checks including verifier and pass the call to poll contract
     function generateNewKeyFromDeactivated(
         DomainObjs.Message memory _message,
         DomainObjs.PubKey memory _encPubKey,
@@ -305,6 +302,8 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
             messageTreeDepth
         );
 
+        uint256 input = 0;
+
         // uint256 input = genProcessDeactivationMessagesPublicInputHash(
         //     poll,
         //     maci.getStateAqRoot(),
@@ -321,8 +320,7 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
 			// 	...ecdhKeypair.pubKey.asCircuitInputs(),
 			// ]),
 
-        // require(verifier.verify(_proof, vk, input), "Verification failed");
-
+        require(verifier.verify(_proof, vk, input), "Verification failed");
 
         // INVOKE POLL
     }

--- a/contracts/contracts/MessageProcessor.sol
+++ b/contracts/contracts/MessageProcessor.sol
@@ -265,7 +265,6 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Utilities {
         require(verifier.verify(_proof, vk, input), "Verification failed");
     }
 
-    // TODO: Perform all the checks including verifier and pass the call to poll contract
     function generateNewKeyFromDeactivated(
         DomainObjs.Message memory _message,
         DomainObjs.PubKey memory _coordPubKey,

--- a/contracts/contracts/MessageProcessor.sol
+++ b/contracts/contracts/MessageProcessor.sol
@@ -291,7 +291,7 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Utilities {
         uint256 input = genGenerateNewKeyFromDeactivatedPublicInputHash(
             maci.getStateAqRoot(),
             deactivatedKeysAq.getMainRoot(DEACT_TREE_DEPTH),
-            hashMessageAndEncPubKey(_message, _coordPubKey),
+            hashMessageData(_message),
             _coordPubKey,
             _sharedPubKey
         );
@@ -373,6 +373,27 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Utilities {
         input[5] = _sharedPublicKey.x;
         input[6] = _sharedPublicKey.y;
         uint256 inputHash = sha256Hash(input);
+
+        return inputHash;
+    }
+
+    function hashMessageData(
+        DomainObjs.Message memory _message
+    ) private pure returns (uint256) {
+        uint256[] memory n = new uint256[](10);
+        
+        n[0] = _message.data[0];
+        n[1] = _message.data[1];
+        n[2] = _message.data[2];
+        n[3] = _message.data[3];
+        n[4] = _message.data[4];
+        n[5] = _message.data[5];
+        n[6] = _message.data[6];
+        n[7] = _message.data[7];
+        n[8] = _message.data[8];
+        n[9] = _message.data[9];
+
+        uint256 inputHash = sha256Hash(n);
 
         return inputHash;
     }

--- a/contracts/contracts/MessageProcessor.sol
+++ b/contracts/contracts/MessageProcessor.sol
@@ -12,7 +12,6 @@ import {Verifier} from "./crypto/Verifier.sol";
 import {VkRegistry} from "./VkRegistry.sol";
 import {DomainObjs} from "./DomainObjs.sol";
 
-
 /*
  * MessageProcessor is used to process messages published by signup users
  * it will process message by batch due to large size of messages
@@ -40,6 +39,8 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
     uint256 public sbCommitment;
 
     Verifier public verifier;
+
+    event DeactivateKey(uint256 keyHash, uint256[2] c1, uint256[2] c2);
 
     constructor(Verifier _verifier) {
         verifier = _verifier;
@@ -141,7 +142,6 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
      * @param _batchLeaves Deactivated keys leaves
      * @param _batchSize The capacity of the subroot of the deactivated keys tree
      */
-     // TODO: reschuffle - Register DeactivateKey event and make sure all listeners switched 
     function confirmDeactivation(
         uint256[][] memory _batchLeaves,
         uint256 _batchSize,
@@ -178,7 +178,7 @@ contract MessageProcessor is Ownable, SnarkCommon, CommonUtilities, Hasher {
             deactivatedKeysAq.enqueue(
                 hash5([keyHash, c1[0], c1[1], c2[0], c2[1]])
             );
-            // emit DeactivateKey(keyHash, c1, c2);
+            emit DeactivateKey(keyHash, c1, c2);
         }
     }
 

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -98,9 +98,13 @@ contract PollFactory is Params, IPubKey, Ownable, PollDeploymentParams {
         // Make the Poll contract own the messageAq contract, so only it can
         // run enqueue/merge
         messageAq.transferOwnership(address(poll));
-        deactivatedKeysAq.transferOwnership(address(poll));
 
-        // init messageAq & deactivatedKeysAq
+        // Make the MessageProcessor contract own the deactivatedKeysAq contract, so only it can
+        // run enqueue/merge
+        // Avoiding 'Stack too deep' by not referencing the local variable _messageProcessorAddress
+        deactivatedKeysAq.transferOwnership(poll.messageProcessorAddress());
+
+        // init messageAq
         poll.init();
 
         // TODO: should this be _maci.owner() instead?
@@ -142,7 +146,7 @@ contract Poll is
 
     uint256 public deactivationChainHash;
 
-    address immutable messageProcessorAddress;
+    address public immutable messageProcessorAddress;
 
     function getDeployTimeAndDuration() public view returns (uint256, uint256) {
         return (deployTime, duration);

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -394,9 +394,20 @@ contract Poll is
      */
     function generateNewKeyFromDeactivated(
         Message memory _message,
-        PubKey memory _encPubKey,
-        uint256 newStateIndex
+        PubKey memory _encPubKey
     ) external returns (uint256) {
+        require(
+            numMessages <= maxValues.maxMessages,
+            ERROR_MAX_MESSAGES_REACHED
+        );
+        require(
+            _encPubKey.x < SNARK_SCALAR_FIELD &&
+                _encPubKey.y < SNARK_SCALAR_FIELD,
+            ERROR_INVALID_PUBKEY
+        );
+
+        uint256 newStateIndex = numMessages + numGeneratedKeys;
+
         unchecked {
             numMessages++;
             numGeneratedKeys++;

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -198,7 +198,6 @@ contract Poll is
     event MergeMessageAqSubRoots(uint256 _numSrQueueOps);
     event MergeMessageAq(uint256 _messageRoot);
     event AttemptKeyDeactivation(Message _message, PubKey _encPubKey);
-    event DeactivateKey(uint256 keyHash, uint256[2] c1, uint256[2] c2);
     event AttemptKeyGeneration(Message _message, PubKey _encPubKey, uint256 _newStateIndex);
 
     ExtContracts public extContracts;

--- a/contracts/ts/__tests__/MACI.test.ts
+++ b/contracts/ts/__tests__/MACI.test.ts
@@ -648,7 +648,6 @@ describe('MACI', () => {
 			expect(packedVals.toString(16)).toEqual(onChainPackedVals.toString(16));
 		});
 
-		// TODO: VM Exception while processing transaction: reverted with custom error 'NO_MORE_MESSAGES()'
 		it('processMessages() should update the state and ballot root commitment', async () => {
 			const pollContractAddress = await maciContract.getPoll(pollId);
 
@@ -906,9 +905,9 @@ describe('MACI', () => {
 
 		it('confirmDeactivation() should revert if not called by an owner', async () => {
 			try {
-				await pollContract
+				await mpContract
 					.connect(otherAccount)
-					.confirmDeactivation([[0]], 0);
+					.confirmDeactivation([[0]], 0, pollContract.address);
 			} catch (e) {
 				const error = 'Ownable: caller is not the owner';
 				expect(
@@ -940,9 +939,10 @@ describe('MACI', () => {
 				salt
 			)) as any
 
-			const tx = await pollContract.confirmDeactivation(
+			const tx = await mpContract.confirmDeactivation(
 				[deactivatedLeaf.asArray()],
 				1,
+				pollContract.address
 			);
 
 			const receipt = await tx.wait();

--- a/docs/elgamal-flow.md
+++ b/docs/elgamal-flow.md
@@ -177,7 +177,6 @@ The verification (partly) relies on the incremental hashing of the (incoming) de
 
 ```solidity
 uint256 input = genProcessDeactivationMessagesPublicInputHash(
-    poll,
     deactivatedKeysAq.getMainRoot(messageTreeSubDepth),
     numSignUps,
     maci.getStateAqRoot(),

--- a/docs/elgamal-flow.md
+++ b/docs/elgamal-flow.md
@@ -144,7 +144,7 @@ const deactivatedLeaf = (new DeactivatedKeyLeaf(
 
 `processDeactivationMessages()` function returns the deactivated-keys tree leaves along with circuit inputs used for generating proof of correct processing (explained in the next step).
 
-The coordinator then submits all deactivated-keys tree leaves in batches to the `Poll` smart contract (`confirmDeactivation()` function). On the smart contract, these leaves are added to the deactivated-keys tree:
+The coordinator then submits all deactivated-keys tree leaves in batches to the `MessageProcessor` smart contract (`confirmDeactivation()` function). On the smart contract, these leaves are added to the deactivated-keys tree:
 
 ```solidity
 extContracts.deactivatedKeysAq.insertSubTree(_subRoot);

--- a/integrationTests/ts/__tests__/suites.ts
+++ b/integrationTests/ts/__tests__/suites.ts
@@ -84,9 +84,10 @@ const executeSuite = async (data: any, expect: any) => {
         execute(setVerifyingKeysCommand)
 
         // Run the create subcommand
+        // TODO: Make signup-deadline dynamic now + 30 days for example
         const createCommand = `node build/index.js create` +
             ` -r ${vkAddress}` +
-            ` --signup-deadline 1689834390`+
+            ` --signup-deadline 1692424915`+
             ` --deactivation-period 86400`
         const createOutput = execute(createCommand).stdout.trim()
         const regMatch = createOutput.match(/MACI: (0x[a-fA-F0-9]{40})/)


### PR DESCRIPTION
This PR moves confirmDeactivation method from Poll contract to MessageProcessor contract due to the size limit.
It also introduces generateNewKeyFromDeactivated on the MP contract that performs proof verficiation before passing the inputs tot the generateNewKeyFromDeactivated on the Poll contract for enqueing the message and calculating the new state index.